### PR TITLE
Simplify Keys and ResultMap structs

### DIFF
--- a/dataloader.go
+++ b/dataloader.go
@@ -165,8 +165,8 @@ func (d *dataloader) LoadMany(ogCtx context.Context, keyArr ...Key) ThunkMany {
 	}
 
 	if len(missed) == 0 {
-		finish(cached)
 		return func() ResultMap {
+			finish(cached)
 			return cached
 		}
 	}

--- a/dataloader.go
+++ b/dataloader.go
@@ -153,21 +153,26 @@ func (d *dataloader) Load(ogCtx context.Context, key Key) Thunk {
 func (d *dataloader) LoadMany(ogCtx context.Context, keyArr ...Key) ThunkMany {
 	ctx, finish := d.tracer.LoadMany(ogCtx, keyArr)
 
-	if r, ok := d.cache.GetResultMap(ctx, keyArr...); ok {
-		d.logger.Logf("cache hit for: %d", keyArr)
-		d.strategy.LoadNoOp(ctx)
-		return func() ResultMap {
-			finish(r)
-
-			return r
+	var cached, missed = ResultMap{}, []Key{}
+	for _, key := range keyArr {
+		if r, ok := d.cache.GetResult(ctx, key); ok {
+			d.logger.Logf("cache hit for: %d", key)
+			d.strategy.LoadNoOp(ctx)
+			cached[key.String()] = r
+		} else {
+			missed = append(missed, key)
 		}
 	}
 
-	thunkMany := d.strategy.LoadMany(ctx, keyArr...)
+	thunkMany := d.strategy.LoadMany(ctx, missed...)
 	return func() ResultMap {
+		cached := cached
 		result := thunkMany()
 		d.cache.SetResultMap(ctx, result)
 
+		for k, v := range cached {
+			result[k] = v
+		}
 		finish(result)
 
 		return result

--- a/dataloader.go
+++ b/dataloader.go
@@ -164,6 +164,13 @@ func (d *dataloader) LoadMany(ogCtx context.Context, keyArr ...Key) ThunkMany {
 		}
 	}
 
+	if len(missed) == 0 {
+		finish(cached)
+		return func() ResultMap {
+			return cached
+		}
+	}
+
 	thunkMany := d.strategy.LoadMany(ctx, missed...)
 	return func() ResultMap {
 		cached := cached

--- a/key.go
+++ b/key.go
@@ -73,17 +73,17 @@ func (k Keys) Keys() []Key {
 }
 
 func (k Keys) RawKeys() []interface{} {
-	result := make([]interface{}, 0, k.Length())
-	for _, key := range k.keys {
-		result = append(result, key.Raw())
+	result := make([]interface{}, k.Length())
+	for i := 0; i < len(k.keys); i++ {
+		result[i] = k.keys[i].Raw()
 	}
 	return result
 }
 
 func (k Keys) StringKeys() []string {
-	result := make([]string, 0, k.Length())
-	for _, key := range k.keys {
-		result = append(result, key.String())
+	result := make([]string, k.Length())
+	for i := 0; i < len(k.keys); i++ {
+		result[i] = k.keys[i].String()
 	}
 	return result
 }

--- a/key.go
+++ b/key.go
@@ -13,71 +13,72 @@ type Key interface {
 }
 
 // Keys wraps an array of keys and contains accessor methods
-type Keys interface {
-	Append(...Key)
-	Capacity() int
-	Length() int
-	ClearAll()
-	// Keys returns a an array of unique results after calling Raw on each key
-	Keys() []interface{}
-	IsEmpty() bool
+type Keys []Key
+
+type StringKey string
+
+func (k StringKey) String() string {
+	return string(k)
 }
 
-type keys struct {
-	k []Key
+func (k StringKey) Raw() interface{} {
+	return k
 }
 
 // NewKeys returns a new instance of the Keys array with the provided capacity.
 func NewKeys(capacity int) Keys {
-	return &keys{
-		k: make([]Key, 0, capacity),
-	}
+	return make([]Key, 0, capacity)
 }
 
 // NewKeysWith is a helper method for returning a new keys array which includes the
 // the provided keys
 func NewKeysWith(key ...Key) Keys {
-	return &keys{
-		k: key,
-	}
+	return append([]Key{}, key...)
 }
 
 // ================================== public methods ==================================
 
-func (k *keys) Append(keys ...Key) {
+func (k *Keys) Append(keys ...Key) {
 	for _, key := range keys {
+		for _, kk := range *k { // skip duplicates
+			if kk == key {
+				return
+			}
+		}
 		if key != nil && key.Raw() != nil { // don't track nil keys
-			k.k = append(k.k, key)
+			*k = append(*k, key)
 		}
 	}
 }
 
-func (k *keys) Capacity() int {
-	return cap(k.k)
+func (k Keys) Capacity() int {
+	return cap(k)
 }
 
-func (k *keys) Length() int {
-	return len(k.k)
+func (k Keys) Length() int {
+	return len(k)
 }
 
-func (k *keys) ClearAll() {
-	k.k = make([]Key, 0, len(k.k))
+func (k *Keys) ClearAll() {
+	*k = []Key{}
 }
 
-func (k *keys) Keys() []interface{} {
+func (k *Keys) Keys() []interface{} {
 	result := make([]interface{}, 0, k.Length())
-	temp := make(map[Key]bool, k.Length())
-
-	for _, val := range k.k {
-		if _, ok := temp[val]; !ok {
-			temp[val] = true
-			result = append(result, val.Raw())
-		}
+	for _, val := range *k {
+		result = append(result, val.Raw())
 	}
-
 	return result
 }
 
-func (k *keys) IsEmpty() bool {
-	return len(k.k) == 0
+func (k *Keys) StringKeys() []string {
+	result := make([]string, 0, k.Length())
+	for _, val := range *k {
+		result = append(result, val.String())
+	}
+	return result
+}
+
+func (k *Keys) IsEmpty() bool {
+	return len(*k) == 0
 }

--- a/key.go
+++ b/key.go
@@ -43,7 +43,7 @@ func NewKeysWith(key ...Key) Keys {
 func (k *Keys) Append(keys ...Key) {
 	ks := make([]Key, 0)
 	for _, key := range keys {
-		if key == nil && key.Raw() == nil { // don't track nil keys
+		if key == nil || key.Raw() == nil { // don't track nil keys
 			continue
 		}
 		for _, kk := range k.keys { // skip duplicates

--- a/key.go
+++ b/key.go
@@ -61,7 +61,7 @@ func (k Keys) Length() int {
 }
 
 func (k *Keys) ClearAll() {
-	*k = []Key{}
+	*k = make([]Key, 0, len(*k))
 }
 
 func (k *Keys) Keys() []interface{} {

--- a/key.go
+++ b/key.go
@@ -13,7 +13,9 @@ type Key interface {
 }
 
 // Keys wraps an array of keys and contains accessor methods
-type Keys []Key
+type Keys struct {
+	keys []Key
+}
 
 type StringKey string
 
@@ -27,59 +29,65 @@ func (k StringKey) Raw() interface{} {
 
 // NewKeys returns a new instance of the Keys array with the provided capacity.
 func NewKeys(capacity int) Keys {
-	return make([]Key, 0, capacity)
+	return Keys{make([]Key, 0, capacity)}
 }
 
 // NewKeysWith is a helper method for returning a new keys array which includes the
 // the provided keys
 func NewKeysWith(key ...Key) Keys {
-	return append([]Key{}, key...)
+	return Keys{append([]Key{}, key...)}
 }
 
 // ================================== public methods ==================================
 
 func (k *Keys) Append(keys ...Key) {
+	ks := make([]Key, 0)
 	for _, key := range keys {
 		if key == nil && key.Raw() == nil { // don't track nil keys
 			continue
 		}
-		for _, kk := range *k { // skip duplicates
+		for _, kk := range k.keys { // skip duplicates
 			if kk == key {
 				return
 			}
 		}
-		*k = append(*k, key)
+		ks = append(ks, key)
 	}
+	k.keys = append(k.keys, ks...)
 }
 
 func (k Keys) Capacity() int {
-	return cap(k)
+	return cap(k.keys)
 }
 
 func (k Keys) Length() int {
-	return len(k)
+	return len(k.keys)
 }
 
-func (k *Keys) ClearAll() {
-	*k = make([]Key, 0, len(*k))
+func (k Keys) ClearAll() {
+	k.keys = make([]Key, 0, len(k.keys))
 }
 
-func (k *Keys) Keys() []interface{} {
+func (k Keys) Keys() []Key {
+	return k.keys
+}
+
+func (k Keys) RawKeys() []interface{} {
 	result := make([]interface{}, 0, k.Length())
-	for _, val := range *k {
-		result = append(result, val.Raw())
+	for _, key := range k.keys {
+		result = append(result, key.Raw())
 	}
 	return result
 }
 
-func (k *Keys) StringKeys() []string {
+func (k Keys) StringKeys() []string {
 	result := make([]string, 0, k.Length())
-	for _, val := range *k {
-		result = append(result, val.String())
+	for _, key := range k.keys {
+		result = append(result, key.String())
 	}
 	return result
 }
 
-func (k *Keys) IsEmpty() bool {
-	return len(*k) == 0
+func (k Keys) IsEmpty() bool {
+	return len(k.keys) == 0
 }

--- a/key.go
+++ b/key.go
@@ -41,19 +41,17 @@ func NewKeysWith(key ...Key) Keys {
 // ================================== public methods ==================================
 
 func (k *Keys) Append(keys ...Key) {
-	ks := make([]Key, 0)
-	for _, key := range keys {
-		if key == nil || key.Raw() == nil { // don't track nil keys
-			continue
-		}
-		for _, kk := range k.keys { // skip duplicates
-			if kk == key {
-				return
+	appendIfMissing := func(keys []Key, k Key) []Key {
+		for _, key := range keys {
+			if key.String() == k.String() {
+				return keys
 			}
 		}
-		ks = append(ks, key)
+		return append(keys, k)
 	}
-	k.keys = append(k.keys, ks...)
+	for _, key := range keys {
+		k.keys = appendIfMissing(k.keys, key)
+	}
 }
 
 func (k Keys) Capacity() int {

--- a/key.go
+++ b/key.go
@@ -40,14 +40,15 @@ func NewKeysWith(key ...Key) Keys {
 
 func (k *Keys) Append(keys ...Key) {
 	for _, key := range keys {
+		if key == nil && key.Raw() == nil { // don't track nil keys
+			continue
+		}
 		for _, kk := range *k { // skip duplicates
 			if kk == key {
 				return
 			}
 		}
-		if key != nil && key.Raw() != nil { // don't track nil keys
-			*k = append(*k, key)
-		}
+		*k = append(*k, key)
 	}
 }
 

--- a/result.go
+++ b/result.go
@@ -7,58 +7,54 @@ type Result struct {
 }
 
 // ResultMap maps each loaded elements Result against the elements unique identifier (Key)
-type ResultMap interface {
-	Set(string, Result)
-	GetValue(Key) (Result, bool)
-	Length() int
-	// Keys returns a slice of all unique identifiers used in the containing map (keys)
-	Keys() []string
-	GetValueForString(string) Result
-}
-
-type resultMap struct {
-	r map[string]Result
-}
+type ResultMap map[Key]Result
 
 // NewResultMap returns a new instance of the result map with the provided capacity.
 // Each value defaults to nil
 func NewResultMap(capacity int) ResultMap {
-	r := make(map[string]Result, capacity)
-
-	return &resultMap{r: r}
+	r := make(map[Key]Result, capacity)
+	return r
 }
 
 // ===================================== public methods =====================================
 
 // Set adds the value to the to the result set.
-func (r *resultMap) Set(identifier string, value Result) {
-	r.r[identifier] = value
+func (r ResultMap) Set(identifier Key, value Result) {
+	r[identifier] = value
 }
 
 // GetValue returns the value from the results for the provided key and true
 // if the value was found, otherwise false.
-func (r *resultMap) GetValue(key Key) (Result, bool) {
+func (r ResultMap) GetValue(key Key) (Result, bool) {
 	if key == nil {
 		return Result{}, false
 	}
 
-	result, ok := r.r[key.String()]
+	result, ok := r[key]
 	return result, ok
 }
 
-func (r *resultMap) GetValueForString(key string) Result {
+func (r ResultMap) GetValueForString(key StringKey) Result {
 	// No need to check ok, missing value from map[Any]interface{} is nil by default.
-	return r.r[key]
+	return r[key]
 }
 
-func (r *resultMap) Keys() []string {
-	res := make([]string, 0, len(r.r))
-	for k := range r.r {
+func (r ResultMap) Keys() []Key {
+	res := make([]Key, 0, len(r))
+	for k, _ := range r {
 		res = append(res, k)
 	}
 	return res
 }
 
-func (r *resultMap) Length() int {
-	return len(r.r)
+func (r ResultMap) StringKeys() []string {
+	res := make([]string, 0, len(r))
+	for k, _ := range r {
+		res = append(res, k.String())
+	}
+	return res
+}
+
+func (r ResultMap) Length() int {
+	return len(r)
 }

--- a/result.go
+++ b/result.go
@@ -7,12 +7,12 @@ type Result struct {
 }
 
 // ResultMap maps each loaded elements Result against the elements unique identifier (Key)
-type ResultMap map[Key]Result
+type ResultMap map[string]Result
 
 // NewResultMap returns a new instance of the result map with the provided capacity.
 // Each value defaults to nil
 func NewResultMap(capacity int) ResultMap {
-	r := make(map[Key]Result, capacity)
+	r := make(map[string]Result, capacity)
 	return r
 }
 
@@ -20,7 +20,7 @@ func NewResultMap(capacity int) ResultMap {
 
 // Set adds the value to the to the result set.
 func (r ResultMap) Set(identifier Key, value Result) {
-	r[identifier] = value
+	r[identifier.String()] = value
 }
 
 // GetValue returns the value from the results for the provided key and true
@@ -30,27 +30,19 @@ func (r ResultMap) GetValue(key Key) (Result, bool) {
 		return Result{}, false
 	}
 
-	result, ok := r[key]
+	result, ok := r[key.String()]
 	return result, ok
 }
 
-func (r ResultMap) GetValueForString(key StringKey) Result {
+func (r ResultMap) GetValueForString(key string) Result {
 	// No need to check ok, missing value from map[Any]interface{} is nil by default.
 	return r[key]
 }
 
-func (r ResultMap) Keys() []Key {
-	res := make([]Key, 0, len(r))
-	for k, _ := range r {
-		res = append(res, k)
-	}
-	return res
-}
-
-func (r ResultMap) StringKeys() []string {
+func (r ResultMap) Keys() []string {
 	res := make([]string, 0, len(r))
 	for k, _ := range r {
-		res = append(res, k.String())
+		res = append(res, k)
 	}
 	return res
 }

--- a/result_test.go
+++ b/result_test.go
@@ -14,7 +14,7 @@ func TestEnsureOKForResult(t *testing.T) {
 	rmap := dataloader.NewResultMap(2)
 	key := PrimaryKey(1)
 	value := dataloader.Result{Result: 1, Err: nil}
-	rmap.Set(key.String(), value)
+	rmap.Set(key, value)
 
 	// invoke/assert
 	result, ok := rmap.GetValue(key)
@@ -27,7 +27,7 @@ func TestEnsureNotOKForResult(t *testing.T) {
 	key := PrimaryKey(1)
 	key2 := PrimaryKey(2)
 	value := dataloader.Result{Result: 1, Err: nil}
-	rmap.Set(key.String(), value)
+	rmap.Set(key, value)
 
 	// invoke/assert
 	result, ok := rmap.GetValue(key2)

--- a/strategies/once/once_test.go
+++ b/strategies/once/once_test.go
@@ -35,7 +35,7 @@ func getBatchFunction(cb func(), result dataloader.Result) dataloader.BatchFunct
 	return func(ctx context.Context, keys dataloader.Keys) *dataloader.ResultMap {
 		cb()
 		m := dataloader.NewResultMap(1)
-		m.Set(keys.Keys()[0].(PrimaryKey).String(), result)
+		m.Set(keys.Keys()[0].(PrimaryKey), result)
 		return &m
 	}
 }
@@ -302,7 +302,7 @@ func TestKeyHandling(t *testing.T) {
 		for i := 0; i < keys.Length(); i++ {
 			key := keys.Keys()[i].(PrimaryKey)
 			if expectedResult[key] != "__skip__" {
-				m.Set(key.String(), dataloader.Result{Result: expectedResult[key], Err: nil})
+				m.Set(key, dataloader.Result{Result: expectedResult[key], Err: nil})
 			}
 		}
 		return &m

--- a/strategies/sozu/sozu.go
+++ b/strategies/sozu/sozu.go
@@ -317,7 +317,7 @@ func buildResultMap(keyArr []dataloader.Key, r dataloader.ResultMap) dataloader.
 
 	for _, k := range keyArr {
 		if val, ok := r.GetValue(k); ok {
-			results.Set(k.String(), val)
+			results.Set(k, val)
 		}
 	}
 

--- a/strategies/sozu/sozu_test.go
+++ b/strategies/sozu/sozu_test.go
@@ -36,8 +36,8 @@ func getBatchFunction(cb func(dataloader.Keys), result string) dataloader.BatchF
 	return func(ctx context.Context, keys dataloader.Keys) *dataloader.ResultMap {
 		cb(keys)
 		m := dataloader.NewResultMap(1)
-		for _, k := range keys.Keys() {
-			key := k.(PrimaryKey).String()
+		for _, k := range keys.RawKeys() {
+			key := k.(PrimaryKey)
 			m.Set(
 				key,
 				dataloader.Result{
@@ -123,7 +123,7 @@ func TestLoadTimeoutTriggered(t *testing.T) {
 	cb := func(keys dataloader.Keys) {
 		blockWG.Wait()
 		callCount += 1
-		k = keys.Keys()
+		k = keys.RawKeys()
 		close(closeChan)
 		wg.Done()
 	}
@@ -206,7 +206,7 @@ func TestLoadManyTimeoutTriggered(t *testing.T) {
 	cb := func(keys dataloader.Keys) {
 		blockWG.Wait()
 		callCount += 1
-		k = keys.Keys()
+		k = keys.RawKeys()
 		close(closeChan)
 		wg.Done()
 	}
@@ -300,7 +300,7 @@ func TestLoadTriggered(t *testing.T) {
 	cb := func(keys dataloader.Keys) {
 		blockWG.Wait()
 		callCount += 1
-		k = keys.Keys()
+		k = keys.RawKeys()
 		close(closeChan)
 		wg.Done()
 	}
@@ -381,7 +381,7 @@ func TestLoadManyTriggered(t *testing.T) {
 	cb := func(keys dataloader.Keys) {
 		blockWG.Wait()
 		callCount += 1
-		k = keys.Keys()
+		k = keys.RawKeys()
 		close(closeChan)
 		wg.Done()
 	}
@@ -458,7 +458,7 @@ func TestLoadBlocked(t *testing.T) {
 	expectedResult := "batch_on_timeout_load_many"
 	cb := func(keys dataloader.Keys) {
 		callCount += 1
-		k = keys.Keys()
+		k = keys.RawKeys()
 		close(closeChan)
 	}
 
@@ -521,7 +521,7 @@ func TestLoadManyBlocked(t *testing.T) {
 	expectedResult := "batch_on_timeout_load_many"
 	cb := func(keys dataloader.Keys) {
 		callCount += 1
-		k = keys.Keys()
+		k = keys.RawKeys()
 		close(closeChan)
 	}
 
@@ -666,9 +666,9 @@ func TestKeyHandling(t *testing.T) {
 	batch := func(ctx context.Context, keys dataloader.Keys) *dataloader.ResultMap {
 		m := dataloader.NewResultMap(2)
 		for i := 0; i < keys.Length(); i++ {
-			key := keys.Keys()[i].(PrimaryKey)
+			key := keys.RawKeys()[i].(PrimaryKey)
 			if expectedResult[key] != "__skip__" {
-				m.Set(key.String(), dataloader.Result{Result: expectedResult[key], Err: nil})
+				m.Set(key, dataloader.Result{Result: expectedResult[key], Err: nil})
 			}
 		}
 		return &m

--- a/strategies/standard/standard.go
+++ b/strategies/standard/standard.go
@@ -2,6 +2,7 @@ package standard
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
@@ -277,9 +278,11 @@ func buildResultMap(keyArr []dataloader.Key, r dataloader.ResultMap) dataloader.
 
 	for _, k := range keyArr {
 		if val, ok := r.GetValue(k); ok {
-			results.Set(k.String(), val)
+			results.Set(k, val)
 		}
 	}
+
+	fmt.Printf("r: %+v\nresults: %+v\n", r, results)
 
 	return results
 }

--- a/strategies/standard/standard_test.go
+++ b/strategies/standard/standard_test.go
@@ -37,7 +37,7 @@ func getBatchFunction(cb func(dataloader.Keys), result string) dataloader.BatchF
 		cb(keys)
 		m := dataloader.NewResultMap(1)
 		for _, k := range keys.Keys() {
-			key := k.(PrimaryKey).String()
+			key := k.(PrimaryKey)
 			m.Set(
 				key,
 				dataloader.Result{
@@ -123,7 +123,7 @@ func TestLoadNoTimeout(t *testing.T) {
 	cb := func(keys dataloader.Keys) {
 		blockWG.Wait()
 		callCount += 1
-		k = keys.Keys()
+		k = keys.RawKeys()
 		close(closeChan)
 		wg.Done()
 	}
@@ -204,7 +204,7 @@ func TestLoadManyNoTimeout(t *testing.T) {
 	cb := func(keys dataloader.Keys) {
 		blockWG.Wait()
 		callCount += 1
-		k = keys.Keys()
+		k = keys.RawKeys()
 		close(closeChan)
 		wg.Done()
 	}
@@ -291,7 +291,7 @@ func TestLoadTimeout(t *testing.T) {
 	cb := func(keys dataloader.Keys) {
 		blockWG.Wait()
 		callCount += 1
-		k = keys.Keys()
+		k = keys.RawKeys()
 		if callCount == 2 {
 			close(closeChan)
 		}
@@ -389,7 +389,7 @@ func TestLoadManyTimeout(t *testing.T) {
 	cb := func(keys dataloader.Keys) {
 		blockWG.Wait()
 		callCount += 1
-		k = keys.Keys()
+		k = keys.RawKeys()
 		if callCount == 2 {
 			close(closeChan)
 		}
@@ -556,7 +556,7 @@ func TestKeyHandling(t *testing.T) {
 		for i := 0; i < keys.Length(); i++ {
 			key := keys.Keys()[i].(PrimaryKey)
 			if expectedResult[key] != "__skip__" {
-				m.Set(key.String(), dataloader.Result{Result: expectedResult[key], Err: nil})
+				m.Set(key, dataloader.Result{Result: expectedResult[key], Err: nil})
 			}
 		}
 		return &m

--- a/trace.go
+++ b/trace.go
@@ -82,7 +82,7 @@ func (*openTracer) Batch(ctx context.Context) (context.Context, BatchFinishFunc)
 	span, spanCtx := opentracing.StartSpanFromContext(ctx, "Dataloader: batch")
 
 	return spanCtx, func(r ResultMap) {
-		span.SetTag("keys", fmt.Sprintf("[%s]", strings.Join(r.Keys(), ", ")))
+		span.SetTag("keys", fmt.Sprintf("[%s]", strings.Join(r.StringKeys(), ", ")))
 		span.Finish()
 	}
 }

--- a/trace.go
+++ b/trace.go
@@ -82,7 +82,7 @@ func (*openTracer) Batch(ctx context.Context) (context.Context, BatchFinishFunc)
 	span, spanCtx := opentracing.StartSpanFromContext(ctx, "Dataloader: batch")
 
 	return spanCtx, func(r ResultMap) {
-		span.SetTag("keys", fmt.Sprintf("[%s]", strings.Join(r.StringKeys(), ", ")))
+		span.SetTag("keys", fmt.Sprintf("[%s]", strings.Join(r.Keys(), ", ")))
 		span.Finish()
 	}
 }


### PR DESCRIPTION
The idea is to remove hard dependencies on strings and use these structs a close to bare metal as possible.  

It may be also possible to remove dependence on defined methods for internal calls in the future since the new definitions are simple native arrays and maps in go.  The benefit here is that downstream consumers can simply choose to use them as such through simple conversions.